### PR TITLE
Update Acknowledgement Message

### DIFF
--- a/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
+++ b/Plugins/CorvusEbMS/src/main/java/hk/hku/cecid/ebms/spa/handler/SignalMessageGenerator.java
@@ -122,9 +122,7 @@ public class SignalMessageGenerator {
 
         final MessageHeader messageHeader = ackMessage.getMessageHeader();
         messageHeader.setRefToMessageId(refToMessageId);
-        if (ackRequestedMessage.getDuplicateElimination()) {
-            messageHeader.setDuplicateElimination();
-        }
+
         Iterator toParties = ackRequestedMessage.getToPartyIds();
         if (toParties.hasNext()) {
             MessageHeader.PartyId party = (MessageHeader.PartyId) toParties


### PR DESCRIPTION
Remove the copy of the Duplicate Elimination setting from a message into the Acknowledgement service message. Since there is no need for this setting in any service message and there are implementations that can't handle this.